### PR TITLE
nix PROJECT_DIR and TARGET_DIR from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-OJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-TARGET_DIR=$(PROJECT_DIR)target
-
 CI_BUILD_NUMBER ?= $(USER)-SNAPSHOT
 CI_IVY_CACHE ?= $(HOME)/.ivy2
 CI_SBT_CACHE ?= $(HOME)/.sbt


### PR DESCRIPTION
As @softprops pointed out here: https://github.com/meetup/oss-best-sbt-jar/pull/1#r78486593, These variables don't look like they're being used anywhere. (one was misspelled and didn't seem to break anything)
